### PR TITLE
Dont fail on startup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+trunk (unreleased)
+* suppress exceptions in top-level bindings thrown when not able to talk
+  to xen. Now this exception will be thrown when the app actually tries to
+  use the event channel API, where it's possible to catch and deal with it.
+
 1.0.1 (30-Jan-2013):
 * only build the C stubs if the xen headers are present
 


### PR DESCRIPTION
Delay exceptions until the user actually calls the event channel API. Otherwise you get ugly unhandleable exceptions on the console like 

```
$ ./main.native 
Fatal error: exception Failure("Failed to open event channel interface: (Failure "Permission denied")")
```
