### PR TITLE
Fix build with newer Xen versions

### DIFF
--- a/lib/eventchn_stubs.c
+++ b/lib/eventchn_stubs.c
@@ -23,6 +23,7 @@
 #include <sys/ioctl.h>
 #include <string.h>
 
+#define XC_WANT_COMPAT_EVTCHN_API
 #include <xenctrl.h>
 #include <xen/xen.h>
 #include <xen/sys/evtchn.h>


### PR DESCRIPTION
Add XC_WANT_COMPAT_EVTCHN_API before including xenctrl.h.