### PR TITLE
Add depexts for CentOS, Fedora and Alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
    - POST_INSTALL_HOOK="opam depext -ui mirage-xen"
    - PINS="xen-evtchn:."
  matrix:
-   #- DISTRO=debian-stable OCAML_VERSION=4.01.0
+   - DISTRO=debian-stable OCAML_VERSION=4.03.0
    - DISTRO=debian-testing OCAML_VERSION=4.02.3
    - DISTRO=debian-unstable OCAML_VERSION=4.03.0
    - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
    - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
-   #- DISTRO=centos-6 OCAML_VERSION=4.02.3
-   #- DISTRO=centos-7 OCAML_VERSION=4.03.0
-   #- DISTRO=fedora-24 OCAML_VERSION=4.03.0
-   #- DISTRO=alpine OCAML_VERSION=4.04.0
+   - DISTRO=centos-6 OCAML_VERSION=4.02.3
+   - DISTRO=centos-7 OCAML_VERSION=4.03.0
+   - DISTRO=fedora-24 OCAML_VERSION=4.03.0
+   - DISTRO=alpine OCAML_VERSION=4.04.0

--- a/xen-evtchn-unix.opam
+++ b/xen-evtchn-unix.opam
@@ -20,8 +20,11 @@ depends: [
   "ounit"      {test}
 ]
 depexts: [
+  [["alpine"] ["xen-dev"]]
   [["debian"] ["libxen-dev"]]
   [["ubuntu"] ["libxen-dev"]]
+  [["centos"] ["xen-devel"]]
+  [["fedora"] ["xen-devel"]]
   [["archlinux"] ["xenstore"]]
 ]
 


### PR DESCRIPTION
- also re-enable travis for `debian-stable` with a more recent OCaml 4.03