### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/xen-evtchn-unix.opam
+++ b/xen-evtchn-unix.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ocaml-evtchn/issues"
 doc: "https://mirage.github.io/ocaml-evtchn/"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "xen-evtchn" {>="2.0.0"}
   "lwt-dllist"
   "lwt"

--- a/xen-evtchn.opam
+++ b/xen-evtchn.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-evtchn/"
 bug-reports: "https://github.com/mirage/ocaml-evtchn/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "lwt"
   "lwt-dllist"
   "cmdliner"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.