### PR TITLE
opam: add xen-devel depext for suse

### DIFF
--- a/xen-evtchn-unix.opam
+++ b/xen-evtchn-unix.opam
@@ -26,6 +26,7 @@ depexts: [
   ["libxen-dev"] {os-distribution = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
+  ["xen-devel"] {os-family = "suse"}
   ["xenstore"] {os-distribution = "archlinux"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-evtchn.git"


### PR DESCRIPTION
The `os-distribution` is `opensuse-leap` but the `os-family` is `suse` which sounds future-proof.

Problem spotted by `ocaml-ci` in https://github.com/mirage/ocaml-vchan/pull/135

Signed-off-by: David Scott <dave@recoil.org>